### PR TITLE
Cannot name the policy data object when using AWS managed policy.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,6 @@ Module usage:
 */
 
 data "aws_iam_policy" "AmazonTextractFullAccess" {
-  name = var.iam_user_policy_name
   arn  = "arn:aws:iam::aws:policy/AmazonTextractFullAccess"
 }
 


### PR DESCRIPTION
## Purpose of pull request
Fix broken terraform.